### PR TITLE
Unify description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage      = "https://crates.io/crates/worker-bindings"
 repository    = "https://github.com/kana-rus/worker-bindings"
 readme        = "README.md"
 license       = "MIT"
-description   = "Automatic bindings to Rust struct"
+description   = "Automatically bind bindings in your `wrangler.toml` into a Rust struct"
 keywords      = ["cloudflare", "workers", "serverless", "wasm"]
 categories    = ["web-programming::http-server", "network-programming", "wasm"]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">worker-bindings</h1>
-<p align="center">Automatically bind bindings in your wrangler.toml into a Rust struct.</p>
+<p align="center">Automatically bind bindings in your `wrangler.toml` into a Rust struct</p>
 
 <div align="right">
     <img alt="test status of worker-bindings" src="https://github.com/kana-rus/worker-bindings/actions/workflows/CI.yaml/badge.svg"/>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod internal;
 
 
-/// Automatically bind bindings in wrangler.toml to Rust struct.
+/// Automatically bind bindings in wrangler.toml to Rust struct
 /// 
 /// - This uses the default (top-level) env by default. You can configure it
 ///   by passing an env name as argument like `#[bindings(dev)]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod internal;
 
 
-/// Automatically bind bindings in wrangler.toml to Rust struct
+/// Automatically bind bindings in your `wrangler.toml` into a Rust struct
 /// 
 /// - This uses the default (top-level) env by default. You can configure it
 ///   by passing an env name as argument like `#[bindings(dev)]`


### PR DESCRIPTION
consistently use

```
Automatically bind bindings in your `wrangler.toml` into a Rust struct
```
as the description